### PR TITLE
Fix `svg!` example in docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iconify"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "blake3",
  "directories",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,9 +125,9 @@ mod svg;
 /// iconify::svg!(
 ///     "pack:name",
 ///     color = "red",
-///     width = 128,
-///     height = 128,
-///     flip = true,
+///     width = "128px",
+///     height = "128px",
+///     flip = "horizontal",
 ///     rotate = "90",
 ///     view_box = true
 /// )


### PR DESCRIPTION
Fixed an example usage of the `svg!` macro, the example used the wrong syntax.